### PR TITLE
Refactor tests to fail per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,25 @@ pip install "memorax[flax]@git+https://github.com/smorad/memorax"
 from memorax.equinox.train_utils import get_residual_memory_models
 import jax
 import jax.numpy as jnp
-from equinox import filter_jit
+from equinox import filter_jit, filter_vmap
+from memorax.equinox.train_utils import add_batch_dim
 
-model = get_residual_memory_models(input=3, hidden=8, output=1, num_layers=2, models=["LRU"], key=jax.random.key(0))["LRU"]
+model = get_residual_memory_models(
+    input=3, hidden=8, output=1, num_layers=2, 
+    models=["LRU"], key=jax.random.key(0)
+)["LRU"]
 
 starts = jnp.array([True, False, False, True, False])
 xs = jnp.zeros((5, 3)) # T x F
 hs, ys = filter_jit(model)(model.initialize_carry(), (xs, starts))
 last_h = filter_jit(model.latest_recurrent_state)(hs)
+
+# With batch dim
+B, T, F = 5, 4, 3
+starts = jnp.zeros((B, T), dtype=bool)
+xs = jnp.zeros((B, T, F))
+hs_0 = add_batch_dim(model.initialize_carry(), B)
+hs, ys = filter_jit(filter_vmap(model))(hs_0, (xs, starts))
 ```
 
 ## Running Baselines

--- a/README.md
+++ b/README.md
@@ -53,18 +53,20 @@ import jax.numpy as jnp
 from equinox import filter_jit, filter_vmap
 from memorax.equinox.train_utils import add_batch_dim
 
+T, F = 5, 6 # time and feature dim
+
 model = get_residual_memory_models(
-    input=3, hidden=8, output=1, num_layers=2, 
+    input=F, hidden=8, output=1, num_layers=2, 
     models=["LRU"], key=jax.random.key(0)
 )["LRU"]
 
 starts = jnp.array([True, False, False, True, False])
-xs = jnp.zeros((5, 3)) # T x F
+xs = jnp.zeros((T, F)) 
 hs, ys = filter_jit(model)(model.initialize_carry(), (xs, starts))
 last_h = filter_jit(model.latest_recurrent_state)(hs)
 
-# With batch dim
-B, T, F = 5, 4, 3
+# with batch dim
+B = 4
 starts = jnp.zeros((B, T), dtype=bool)
 xs = jnp.zeros((B, T, F))
 hs_0 = add_batch_dim(model.initialize_carry(), B)

--- a/tests/test_associative_equinox.py
+++ b/tests/test_associative_equinox.py
@@ -1,4 +1,5 @@
 """Proves the correctness (empirically) of associative updates"""
+import pytest
 from functools import partial
 
 import jax
@@ -29,7 +30,9 @@ def map_assert(monoid, a, b):
             f"Monoid {type(monoid).__name__} failed associativity test:\n{a} != \n{b}, \nerror: {error}"
         )
 
-def prove_semigroup_correctness(sg: Semigroup):
+
+@pytest.mark.parametrize("name, sg", get_semigroups(recurrent_size=3, key=jax.random.PRNGKey(0)).items())
+def test_semigroup_correctness(name: str, sg: Semigroup):
     initial_state = sg.initialize_carry()
     x1 = jax.tree.map(partial(random_state, key=jax.random.PRNGKey(1)), initial_state)
     x2 = jax.tree.map(partial(random_state, key=jax.random.PRNGKey(2)), initial_state)
@@ -46,10 +49,6 @@ def prove_semigroup_correctness(sg: Semigroup):
 
     jax.tree.map(partial(map_assert, sg), a, b)
 
-
-def test_semigroup_correctness():
-    for name, sg in get_semigroups(recurrent_size=3, key=jax.random.PRNGKey(0)).items():
-        prove_semigroup_correctness(sg)
 
 if __name__ == '__main__':
     test_semigroup_correctness()

--- a/tests/test_associative_linen.py
+++ b/tests/test_associative_linen.py
@@ -1,5 +1,6 @@
 """Proves the correctness (empirically) of associative updates"""
 from functools import partial
+import pytest
 
 import jax
 import jax.numpy as jnp
@@ -29,7 +30,8 @@ def map_assert(monoid, a, b):
             f"Monoid {type(monoid).__name__} failed associativity test:\n{a} != \n{b}, \nerror: {error}"
         )
 
-def prove_semigroup_correctness(sg: Semigroup):
+@pytest.mark.parametrize("name, sg", get_semigroups(recurrent_size=3).items())
+def test_semigroup_correctness(name: str, sg: Semigroup):
     initial_state = sg.zero_carry()
     x1 = jax.tree.map(partial(random_state, key=jax.random.PRNGKey(1)), initial_state)
     x2 = jax.tree.map(partial(random_state, key=jax.random.PRNGKey(2)), initial_state)
@@ -48,9 +50,6 @@ def prove_semigroup_correctness(sg: Semigroup):
     jax.tree.map(partial(map_assert, sg), a, b)
 
 
-def test_semigroup_correctness():
-    for name, sg in get_semigroups(recurrent_size=3).items():
-        prove_semigroup_correctness(sg)
 
 if __name__ == '__main__':
     test_semigroup_correctness()

--- a/tests/test_initial_input_equinox.py
+++ b/tests/test_initial_input_equinox.py
@@ -81,22 +81,5 @@ def test_initial_input(
     ), f"Failed {model_name}, expected {get_desired_accuracies()[model_name]}, got {accuracies}"
 
 
-
-# def test_classify():
-#     test_size = 4
-#     hidden = 8
-#     models = get_residual_memory_models(
-#         test_size, hidden, test_size - 1, key=jax.random.key(0), 
-#     )
-#     for model_name, model in models.items():
-#         losses, accuracies = train_initial_input(model)
-#         losses = losses[-100:].mean()
-#         accuracies = accuracies[-100:].mean()
-#         print(f"{model_name} mean accuracy: {accuracies:0.3f}")
-#         assert (
-#             accuracies >= get_desired_accuracies()[model_name]
-#         ), f"Failed {model_name}, expected {get_desired_accuracies()[model_name]}, got {accuracies}"
-
-
 if __name__ == "__main__":
     test_initial_input()

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -79,18 +79,20 @@ def test_readme_quickstart():
     from equinox import filter_jit, filter_vmap
     from memorax.equinox.train_utils import add_batch_dim
 
+    T, F = 5, 6 # time and feature dim
+
     model = get_residual_memory_models(
-        input=3, hidden=8, output=1, num_layers=2, 
+        input=F, hidden=8, output=1, num_layers=2, 
         models=["LRU"], key=jax.random.key(0)
     )["LRU"]
 
     starts = jnp.array([True, False, False, True, False])
-    xs = jnp.zeros((5, 3)) # T x F
+    xs = jnp.zeros((T, F)) 
     hs, ys = filter_jit(model)(model.initialize_carry(), (xs, starts))
     last_h = filter_jit(model.latest_recurrent_state)(hs)
 
-    # With batch dim
-    B, T, F = 5, 4, 3
+    # with batch dim
+    B = 4
     starts = jnp.zeros((B, T), dtype=bool)
     xs = jnp.zeros((B, T, F))
     hs_0 = add_batch_dim(model.initialize_carry(), B)

--- a/tests/test_reset_equinox.py
+++ b/tests/test_reset_equinox.py
@@ -2,33 +2,34 @@
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import pytest
 
 from memorax.equinox.train_utils import add_batch_dim, get_residual_memory_models
 
-def test_reset():
-    models = get_residual_memory_models(
+@pytest.mark.parametrize("name, model", get_residual_memory_models(
         input=1, hidden=8, output=10, num_layers=2, key=jax.random.key(0)
-    )
-    for name, model in models.items():
-        print(f"Testing {name}")
-        L = 2048
-        B = 32
-        x_long = jax.random.uniform(jax.random.key(1), (L, 1))
-        x_short = x_long.reshape(B, -1, 1)
-        start_long = jnp.zeros(L, dtype=bool).at[jnp.arange(0, L, B)].set(True)
-        start_short = start_long.reshape(B, -1)
+    ).items()
+)
+def test_reset(name, model):
+    print(f"Testing {name}")
+    L = 2048
+    B = 32
+    x_long = jax.random.uniform(jax.random.key(1), (L, 1))
+    x_short = x_long.reshape(B, -1, 1)
+    start_long = jnp.zeros(L, dtype=bool).at[jnp.arange(0, L, B)].set(True)
+    start_short = start_long.reshape(B, -1)
 
-        h0_long = model.initialize_carry()
-        h_long, out_long = model(h0_long, (x_long, start_long))
-        h0_short = add_batch_dim(h0_long, B)
-        h_short, out_short = eqx.filter_vmap(model)(h0_short, (x_short, start_short))
+    h0_long = model.initialize_carry()
+    h_long, out_long = model(h0_long, (x_long, start_long))
+    h0_short = add_batch_dim(h0_long, B)
+    h_short, out_short = eqx.filter_vmap(model)(h0_short, (x_short, start_short))
 
-        assert jnp.allclose(
-            out_long,
-            out_short.reshape(L, *out_short.shape[2:]),
-            atol=1e-5,
-            rtol=1e-5,
-        ), f"Reset failed for {name}"
+    assert jnp.allclose(
+        out_long,
+        out_short.reshape(L, *out_short.shape[2:]),
+        atol=1e-5,
+        rtol=1e-5,
+    ), f"Reset failed for {name}"
 
 if __name__ == "__main__":
     test_reset()

--- a/tests/test_reset_linen.py
+++ b/tests/test_reset_linen.py
@@ -1,37 +1,38 @@
 """Ensure that the reset model is equivalent to a non-reset batched model"""
+import pytest
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 
 from memorax.linen.train_utils import add_batch_dim, get_residual_memory_models
 
-def test_reset():
-    models = get_residual_memory_models(
+@pytest.mark.parametrize("name, model", get_residual_memory_models(
         hidden=8, output=10, num_layers=2
-    )
-    for name, model in models.items():
-        print(f"Testing {name}")
-        L = 2048
-        B = 32
-        x_long = jax.random.uniform(jax.random.key(1), (L, 1))
-        x_short = x_long.reshape(B, -1, 1)
-        start_long = jnp.zeros(L, dtype=bool).at[jnp.arange(0, L, B)].set(True)
-        start_short = start_long.reshape(B, -1)
+    ).items()
+)
+def test_reset(name, model):
+    print(f"Testing {name}")
+    L = 2048
+    B = 32
+    x_long = jax.random.uniform(jax.random.key(1), (L, 1))
+    x_short = x_long.reshape(B, -1, 1)
+    start_long = jnp.zeros(L, dtype=bool).at[jnp.arange(0, L, B)].set(True)
+    start_short = start_long.reshape(B, -1)
 
-        dummy_h = model.zero_carry()
-        params = model.init(jax.random.key(0), dummy_h, (x_long, start_long))
-        h0_long = model.apply(params, method='initialize_carry')
-        h0_short = add_batch_dim(h0_long, B)
+    dummy_h = model.zero_carry()
+    params = model.init(jax.random.key(0), dummy_h, (x_long, start_long))
+    h0_long = model.apply(params, method='initialize_carry')
+    h0_short = add_batch_dim(h0_long, B)
 
-        h_long, out_long = model.apply(params, h0_long, (x_long, start_long))
-        h_short, out_short = jax.vmap(model.apply, in_axes=(None, 0, (0, 0)))(params, h0_short, (x_short, start_short))
+    h_long, out_long = model.apply(params, h0_long, (x_long, start_long))
+    h_short, out_short = jax.vmap(model.apply, in_axes=(None, 0, (0, 0)))(params, h0_short, (x_short, start_short))
 
-        assert jnp.allclose(
-            out_long,
-            out_short.reshape(L, *out_short.shape[2:]),
-            atol=1e-5,
-            rtol=1e-5,
-        ), f"Reset failed for {name}"
+    assert jnp.allclose(
+        out_long,
+        out_short.reshape(L, *out_short.shape[2:]),
+        atol=1e-5,
+        rtol=1e-5,
+    ), f"Reset failed for {name}"
 
 if __name__ == "__main__":
     test_reset()


### PR DESCRIPTION
Previously, tests were run in a for loop, making it difficult to narrow down which model was failing. This refactors all tests such that a single test is run for each module.