### PR TITLE
Add flax S6 model

### DIFF
--- a/memorax/equinox/semigroups/s6.py
+++ b/memorax/equinox/semigroups/s6.py
@@ -94,7 +94,7 @@ class S6(GRAS):
 
         self.A_log = jax.random.normal(keys[0], (self.recurrent_size,))
         self.B = nn.Linear(self.hidden_size, self.recurrent_size * self.recurrent_size, key=keys[1], use_bias=False)
-        self.C = nn.Linear(self.recurrent_size, self.hidden_size, key=keys[2], use_bias=False)
+        self.C = nn.Linear(self.recurrent_size, self.hidden_size * self.recurrent_size, key=keys[2], use_bias=False)
         self.dt = nn.Sequential([
             nn.Linear(self.hidden_size, self.recurrent_size, key=keys[3]),
             nn.Lambda(jax.nn.softplus)
@@ -124,8 +124,8 @@ class S6(GRAS):
         state, reset_flag = h
         emb, start = x
         lambdas, lambda_x_Bu = state
-        C = self.C(emb)
-        out = C * lambda_x_Bu 
+        C = self.C(emb).reshape(self.hidden_size, self.recurrent_size)
+        out = C @ lambda_x_Bu 
         return out
 
     @jaxtyped(typechecker=typechecker)

--- a/memorax/linen/semigroups/s6.py
+++ b/memorax/linen/semigroups/s6.py
@@ -1,0 +1,124 @@
+# https://github.com/NicolasZucchet/minimal-S6/blob/main/lru/model.py
+from functools import partial
+from beartype.typing import Optional, Tuple
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+from beartype import beartype as typechecker
+from jaxtyping import Array, Float, PRNGKeyArray, Shaped, jaxtyped
+
+from memorax.mtypes import Input, StartFlag
+from memorax.linen.groups import Semigroup, Resettable
+from memorax.linen.gras import GRAS
+from memorax.linen.scans import semigroup_scan
+
+S6RecurrentState = Tuple[Float[Array, "Recurrent"], Float[Array, "Recurrent"]]
+S6RecurrentStateWithReset = Tuple[S6RecurrentState, StartFlag]
+
+
+class S6Semigroup(Semigroup):
+    """The diagonal S6 semigroup (recurrent update) from https://arxiv.org/abs/2312.00752.
+    
+    This is a S5/LRU recurrent update with a learnable timestep parameter. """
+
+    recurrent_size: int
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> S6RecurrentState:
+        # Represent a diagonal matrix as a vector
+        return (
+            jnp.ones((self.recurrent_size,)),
+            jnp.zeros((self.recurrent_size)),
+        )
+
+    @nn.nowrap
+    def zero_carry(self) -> S6RecurrentState:
+        return (
+            jnp.zeros((self.recurrent_size,)),
+            jnp.zeros((self.recurrent_size)),
+        )
+
+    @jaxtyped(typechecker=typechecker)
+    @nn.compact
+    def __call__(
+        self, carry: S6RecurrentState, input: S6RecurrentState
+    ) -> S6RecurrentState:
+        # Ax + Bu, but A is diagonal, and we treat it as a vector
+        # So we can be more efficient by writing Ax as vec(A) * x
+        A_i, bu_i = carry
+        A_j, bu_j = input
+        return A_j * A_i, A_j * bu_i + bu_j
+
+
+class S6(GRAS):
+    """
+    The full-rank S6 SSM, an SSM with a trainable dt. 
+    The recurrent matrix A is diagonal, but the B, C matrices are full-rank.
+
+    You might want to use this as a building block for a more complex model.
+    """
+
+    hidden_size: int  # output dimensions
+    recurrent_size: int  # hidden state dimension
+
+    def setup(self):
+        self.A_log = self.param(
+            "A_log",
+            jax.random.normal,
+            (self.recurrent_size,),
+        )
+        self.B = nn.Dense(self.recurrent_size * self.recurrent_size)
+        self.C = nn.Dense(self.recurrent_size * self.hidden_size)
+        self.dt = nn.Sequential([
+            nn.Dense(self.recurrent_size),
+            jax.nn.softplus
+        ])
+
+    @jaxtyped(typechecker=typechecker)
+    def forward_map(self, x: Input, key: Optional[Shaped[PRNGKeyArray, ""]] = None):
+        emb, start = x
+        dt = self.dt(emb)
+        A = -jnp.exp(self.A_log)
+        A_bar = jnp.exp(dt * A)
+        B = self.B(emb).reshape(self.recurrent_size, self.recurrent_size)
+        # NOTE: A and B are diagonal so we can compute B_bar more simply than the mamba paper
+        # Thankfully, inv(A) is just 1 / A if A is diagonal
+        # Furthermore the dt's cancel: 1 / (dt A) with dt B
+        B_bar = jnp.diag(1 / A * (A_bar - 1.0)) @ B
+        Bu = B_bar @ emb
+        return (A_bar, Bu), start
+
+    @jaxtyped(typechecker=typechecker)
+    def backward_map(
+        self,
+        h: S6RecurrentStateWithReset,
+        x: Input,
+        key: Optional[Shaped[PRNGKeyArray, ""]] = None,
+    ) -> Float[Array, "{self.recurrent_size}"]:
+        state, reset_flag = h
+        emb, start = x
+        lambdas, lambda_x_Bu = state
+        C = self.C(emb).reshape(self.hidden_size, self.recurrent_size)
+        out = C @ lambda_x_Bu
+        return out
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> S6RecurrentStateWithReset:
+        return self.algebra.initialize_carry(key)
+
+    @nn.nowrap
+    def zero_carry(self) -> S6RecurrentStateWithReset:
+        return self.algebra.zero_carry()
+
+    @staticmethod
+    def default_algebra(**kwargs):
+        return Resettable(S6Semigroup(**kwargs))
+
+    @staticmethod
+    def default_scan():
+        return semigroup_scan

--- a/memorax/linen/train_utils.py
+++ b/memorax/linen/train_utils.py
@@ -13,6 +13,7 @@ from memorax.linen.models.residual import ResidualModel
 from memorax.linen.semigroups.fart import FARTSemigroup, FART
 from memorax.linen.semigroups.lru import LRUSemigroup, LRU
 from memorax.linen.semigroups.s6d import S6DSemigroup, S6D
+from memorax.linen.semigroups.s6 import S6Semigroup, S6
 
 
 def add_batch_dim(h, batch_size: int, axis: int = 0) -> Shaped[Array, "Batch ..."]:
@@ -84,6 +85,7 @@ def get_semigroups(
         "FART": FARTSemigroup(recurrent_size),
         "LRU": LRUSemigroup(recurrent_size),
         "S6D": S6DSemigroup(recurrent_size),
+        "S6": S6Semigroup(recurrent_size),
     }
 
 def get_residual_memory_models(
@@ -107,6 +109,12 @@ def get_residual_memory_models(
         "S6D": lambda recurrent_size: S6D(
             algebra=S6D.default_algebra(recurrent_size=recurrent_size),
             scan=S6D.default_scan(),
+            hidden_size=recurrent_size,
+            recurrent_size=recurrent_size,
+        ),
+        "S6": lambda recurrent_size: S6(
+            algebra=S6.default_algebra(recurrent_size=recurrent_size),
+            scan=S6.default_scan(),
             hidden_size=recurrent_size,
             recurrent_size=recurrent_size,
         ),

--- a/tests/test_initial_input_linen.py
+++ b/tests/test_initial_input_linen.py
@@ -12,6 +12,7 @@ def get_desired_accuracies():
     return {
         "LRU": 0.999,
         "S6D": 0.999,
+        "S6": 0.999,
         "FART": 0.999,
         "GRU": 0.999,
     }


### PR DESCRIPTION
This PR adds the S6 model using full-rank B and C matrices for flax. It also fixes a small bug where the C matrix for equinox was not full rank.