### PR TITLE
Add stack semigroup and tests

### DIFF
--- a/memorax/equinox/semigroups/stack.py
+++ b/memorax/equinox/semigroups/stack.py
@@ -1,0 +1,135 @@
+from beartype.typing import Callable, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from beartype import beartype as typechecker
+from equinox import nn
+from jaxtyping import Array, Float, PRNGKeyArray, Shaped, jaxtyped, Bool
+
+from memorax.equinox.groups import BinaryAlgebra, Semigroup, Resettable
+from memorax.equinox.gras import GRAS
+from memorax.mtypes import Input, StartFlag
+from memorax.equinox.scans import semigroup_scan
+from memorax.utils import combine_and_right_align
+
+StackRecurrentState = Tuple[Float[Array, "Stack Recurrent"], Bool[Array, "Stack"]]
+StackRecurrentStateWithReset = Tuple[StackRecurrentState, StartFlag]
+
+
+class StackSemigroup(Semigroup):
+    """A sliding window semigroup example.
+
+    This allows you to define recurrent function that, for example,
+    rely on the two (or more) most recent inputs through a sliding window.
+
+    Applications include dot-product attention, RWKV, Fast weight programmer, etc.
+    """
+    stack_size: int
+    recurrent_size: int
+
+    def __init__(self, recurrent_size: int, stack_size: int):
+        self.stack_size = stack_size
+        self.recurrent_size = recurrent_size
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> StackRecurrentState:
+        stack = jnp.zeros((self.stack_size, self.recurrent_size))
+        #return stack
+        # Valid (non-pad) mask
+        mask = jnp.zeros((self.stack_size,), dtype=bool)
+        return (stack, mask)
+
+    @jaxtyped(typechecker=typechecker)
+    def __call__(
+        self, carry: StackRecurrentState, input: StackRecurrentState
+    ) -> StackRecurrentState:
+        # We would like to do the below
+        # But cannot due to concretization error
+        # Caused by dynamic indexing (mask)
+        #
+        # left = cstack[cmask]
+        # right = stack[mask]
+
+        # mleft = cmask[cmask]
+        # mright = mask[mask]
+
+        # stack = jnp.concatenate([left, right])
+        # mask = jnp.concatenate([mleft, mright])
+
+        # So we use a hacky concrete_combine function
+        cstack, cmask = carry
+        stack, mask = input
+        out_stack, out_mask = combine_and_right_align(cstack, cmask, stack, mask)
+        return (out_stack, out_mask)
+
+
+class Stack(GRAS):
+    """A fairly straightforward "recurrent" model that merely keeps a sliding
+    window of the past. You may use this model as a blueprint to implement 
+    "less recurrent" models that rely on more than the current input and recurrent state.
+
+    Applications include dot-product attention, RWKV, Fast weight programmer, etc.
+    """
+
+    recurrent_size: int
+    stack_size: int
+    scan: Callable[
+        [
+            Callable[
+                [StackRecurrentStateWithReset, StackRecurrentStateWithReset],
+                StackRecurrentStateWithReset,
+            ],
+            StackRecurrentStateWithReset,
+            StackRecurrentStateWithReset,
+        ],
+        StackRecurrentStateWithReset,
+    ]
+    algebra: BinaryAlgebra
+
+    g: nn.Sequential
+
+    def __init__(self, recurrent_size, stack_size, key):
+        self.recurrent_size = recurrent_size
+        self.stack_size = stack_size
+        self.algebra = Resettable(StackSemigroup(recurrent_size, stack_size=stack_size))
+        self.scan = semigroup_scan
+        self.g = nn.Linear(recurrent_size * stack_size, recurrent_size, key=key)
+
+    @jaxtyped(typechecker=typechecker)
+    def forward_map(
+        self, x: Input, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> StackRecurrentStateWithReset:
+        emb, start = x
+        # Add stack dim for concat
+        #return emb.reshape(1, -1), start
+        mask = jnp.concatenate([
+            jnp.zeros((self.stack_size - 1), dtype=bool),
+            jnp.ones((1,), dtype=bool)
+        ])
+        emb = jnp.concatenate([
+            jnp.zeros((self.stack_size - 1, *emb.shape), dtype=emb.dtype),
+            emb.reshape(1, -1)
+        ])
+        return (emb, mask), start
+
+    @jaxtyped(typechecker=typechecker)
+    def backward_map(
+        self,
+        h: StackRecurrentStateWithReset,
+        x: Input,
+        key: Optional[Shaped[PRNGKeyArray, ""]] = None,
+    ) -> Float[Array, "{self.recurrent_size}"]:
+        emb, start = x
+        state, reset_carry = h
+        z, mask = state
+        # You can do something more intelligent with masking if needed
+        z = self.g(z.reshape(-1))
+        return z
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> StackRecurrentStateWithReset:
+        return self.algebra.initialize_carry(key)

--- a/memorax/equinox/semigroups/stack.py
+++ b/memorax/equinox/semigroups/stack.py
@@ -55,8 +55,8 @@ class StackSemigroup(Semigroup):
         # mleft = cmask[cmask]
         # mright = mask[mask]
 
-        # stack = jnp.concatenate([left, right])
-        # mask = jnp.concatenate([mleft, mright])
+        # stack = jnp.concatenate([left, right])[-stack_size:]
+        # mask = jnp.concatenate([mleft, mright])[-stack_size:]
 
         # So we use a hacky concrete_combine function
         cstack, cmask = carry

--- a/memorax/equinox/semigroups/stack.py
+++ b/memorax/equinox/semigroups/stack.py
@@ -58,7 +58,7 @@ class StackSemigroup(Semigroup):
         # stack = jnp.concatenate([left, right])[-stack_size:]
         # mask = jnp.concatenate([mleft, mright])[-stack_size:]
 
-        # So we use a hacky concrete_combine function
+        # So we use a tricky function instead
         cstack, cmask = carry
         stack, mask = input
         out_stack, out_mask = combine_and_right_align(cstack, cmask, stack, mask)

--- a/memorax/equinox/train_utils.py
+++ b/memorax/equinox/train_utils.py
@@ -268,6 +268,9 @@ def get_residual_memory_models(
         "LinearRNN": lambda recurrent_size, key: LinearRecurrent(
             recurrent_size=recurrent_size, key=key
         ),
+        "Stack": lambda recurrent_size, key: Stack(
+            recurrent_size=recurrent_size, stack_size=4, key=key
+        ),
         # set actions
         "GRU": lambda recurrent_size, key: GRU(recurrent_size=recurrent_size, key=key),
         "Elman": lambda recurrent_size, key: Elman(

--- a/memorax/equinox/train_utils.py
+++ b/memorax/equinox/train_utils.py
@@ -22,6 +22,7 @@ from memorax.equinox.semigroups.spherical import PSpherical, PSphericalSemigroup
 from memorax.equinox.semigroups.s6 import S6, S6Semigroup
 from memorax.equinox.semigroups.s6d import S6D, S6DSemigroup
 from memorax.equinox.semigroups.mlp import MLP
+from memorax.equinox.semigroups.stack import Stack, StackSemigroup
 
 
 def add_batch_dim(h, batch_size: int, axis: int = 0) -> Shaped[Array, "Batch ..."]:
@@ -218,6 +219,7 @@ def get_semigroups(
         "s6": S6Semigroup(recurrent_size),
         "s6d": S6DSemigroup(recurrent_size),
         "nmax": NMaxSemigroup(recurrent_size),
+        "stack": StackSemigroup(recurrent_size, stack_size=4)
     }
 
 def get_residual_memory_models(

--- a/memorax/utils.py
+++ b/memorax/utils.py
@@ -34,3 +34,108 @@ def transformer_positional_encoding(
     pos_encoding = pos_encoding.at[0::2].set(jnp.sin(position * div_term))
     pos_encoding = pos_encoding.at[1::2].set(jnp.cos(position * div_term))
     return pos_encoding
+
+def concrete_combine(left_state, right_state, T: int):
+    """
+    Concatenate two masked arrays in a compilable/scannable fashion.
+
+    This performs the following operations, whilst avoiding a concretization error
+    caused by dynamic (masked) indexing:
+
+        left = cstack[cmask]
+        right = stack[mask]
+
+        mleft = cmask[cmask]
+        mright = mask[mask]
+
+        stack = jnp.concatenate([left, right])
+        mask = jnp.concatenate([mleft, mright])
+    """
+    left_stack, left_size = left_state    # Shapes (B, T, F), (B,)
+    right_stack, right_size = right_state # Shapes (B, T, F), (B,)
+
+    # The logic here is to place the valid items from `right_stack`
+    # immediately after the valid items from `left_stack`.
+
+    # 1. Start with the left stack. It already contains its items packed at the front.
+    new_stack = left_stack
+
+    # 2. Determine where each item from the right stack should go.
+    # The destination indices start after `left_size`.
+    # Shape of right_indices: (T,)
+    right_indices = jnp.arange(T)
+    # Shape of dest_indices: (B, T). Broadcasting `left_size` from (B,) to (B, 1).
+    dest_indices = left_size[:, None] + right_indices
+
+    # 3. Create a mask for the valid items in the right stack.
+    # Shape of right_mask: (B, T)
+    right_mask = right_indices < right_size[:, None]
+
+    # 4. Perform a batched scatter-add to place right_stack's items.
+    
+    # Get batch dimension info
+    batch_size = left_stack.shape[0]
+    
+    # Create batch indices: [[0], [1], ..., [B-1]]. Shape: (B, 1)
+    batch_indices = jnp.arange(batch_size)[:, None]
+    
+    # Mask the updates so we only add valid items from right_stack.
+    # The `right_mask[..., None]` broadcasts (B, T) -> (B, T, 1) -> (B, T, F)
+    updates = jnp.where(right_mask[..., None], right_stack, 0)
+    
+    # Scatter using the batch and destination indices.
+    new_stack = new_stack.at[batch_indices, dest_indices].add(updates)
+    
+    # 5. Calculate the new total size.
+    new_size = left_size + right_size
+    
+    return new_stack, new_size
+
+def combine_and_right_align(left_array, left_mask, right_array, right_mask):
+    """
+    JIT-compatible function to combine two masked arrays and right-align the result.
+
+    This is the JAX-native equivalent of:
+
+    # left = left_array[left_mask]
+    # right = right_array[right_mask]
+    # combined = jnp.concatenate([left, right])
+    # # Manual right-alignment:
+    # result = jnp.zeros_like(left_array)
+    # result = result.at[-len(combined):].set(combined)
+    """
+    # Ensure inputs are JAX arrays and masks are boolean
+    left_mask = left_mask.astype(bool)
+    right_mask = right_mask.astype(bool)
+
+    # Get the static size N from the input array.
+    N = left_array.shape[0]
+
+    # 1. Combine the inputs into single, larger arrays.
+    #    This is a safe operation as shapes are static.
+    combined_stack = jnp.concatenate([left_array, right_array], axis=0)
+    combined_mask = jnp.concatenate([left_mask, right_mask], axis=0)
+
+    # 2. Count the total number of valid elements.
+    total_valid = jnp.sum(combined_mask)
+
+    # 3. Calculate destination indices for right-alignment.
+    #    The 'rank' is the 0-indexed position of each valid item (0th, 1st, ...).
+    ranks = jnp.cumsum(combined_mask) - 1
+    #    The destination block starts at index N - total_valid.
+    start_index = N - total_valid
+    dest_indices = start_index + ranks
+
+    # 4. Perform the scatter operation.
+    #    Start with a zeroed output array.
+    new_stack = jnp.zeros_like(left_array)
+    #    Prepare updates: valid items from combined_stack, zeros elsewhere.
+    updates = jnp.where(combined_mask.reshape(-1, 1), combined_stack, 0)
+    #    Scatter-add the updates to their right-aligned positions.
+    new_stack = new_stack.at[dest_indices].add(updates)
+
+    # 5. Generate the final right-aligned mask.
+    #    The mask should be True for all indices >= start_index.
+    new_mask = jnp.arange(N) >= start_index
+    
+    return new_stack, new_mask

--- a/memorax/utils.py
+++ b/memorax/utils.py
@@ -35,62 +35,6 @@ def transformer_positional_encoding(
     pos_encoding = pos_encoding.at[1::2].set(jnp.cos(position * div_term))
     return pos_encoding
 
-def concrete_combine(left_state, right_state, T: int):
-    """
-    Concatenate two masked arrays in a compilable/scannable fashion.
-
-    This performs the following operations, whilst avoiding a concretization error
-    caused by dynamic (masked) indexing:
-
-        left = cstack[cmask]
-        right = stack[mask]
-
-        mleft = cmask[cmask]
-        mright = mask[mask]
-
-        stack = jnp.concatenate([left, right])
-        mask = jnp.concatenate([mleft, mright])
-    """
-    left_stack, left_size = left_state    # Shapes (B, T, F), (B,)
-    right_stack, right_size = right_state # Shapes (B, T, F), (B,)
-
-    # The logic here is to place the valid items from `right_stack`
-    # immediately after the valid items from `left_stack`.
-
-    # 1. Start with the left stack. It already contains its items packed at the front.
-    new_stack = left_stack
-
-    # 2. Determine where each item from the right stack should go.
-    # The destination indices start after `left_size`.
-    # Shape of right_indices: (T,)
-    right_indices = jnp.arange(T)
-    # Shape of dest_indices: (B, T). Broadcasting `left_size` from (B,) to (B, 1).
-    dest_indices = left_size[:, None] + right_indices
-
-    # 3. Create a mask for the valid items in the right stack.
-    # Shape of right_mask: (B, T)
-    right_mask = right_indices < right_size[:, None]
-
-    # 4. Perform a batched scatter-add to place right_stack's items.
-    
-    # Get batch dimension info
-    batch_size = left_stack.shape[0]
-    
-    # Create batch indices: [[0], [1], ..., [B-1]]. Shape: (B, 1)
-    batch_indices = jnp.arange(batch_size)[:, None]
-    
-    # Mask the updates so we only add valid items from right_stack.
-    # The `right_mask[..., None]` broadcasts (B, T) -> (B, T, 1) -> (B, T, F)
-    updates = jnp.where(right_mask[..., None], right_stack, 0)
-    
-    # Scatter using the batch and destination indices.
-    new_stack = new_stack.at[batch_indices, dest_indices].add(updates)
-    
-    # 5. Calculate the new total size.
-    new_size = left_size + right_size
-    
-    return new_stack, new_size
-
 def combine_and_right_align(left_array, left_mask, right_array, right_mask):
     """
     JIT-compatible function to combine two masked arrays and right-align the result.

--- a/tests/test_initial_input_equinox.py
+++ b/tests/test_initial_input_equinox.py
@@ -11,6 +11,7 @@ from memorax.equinox.train_utils import get_residual_memory_models
 def get_desired_accuracies():
     return {
         "MLP": 0,
+        "Stack": 0,
         "DLSE": 0.999,
         "FFM": 0.999,
         "FART": 0.999,

--- a/tests/test_stack_equinox.py
+++ b/tests/test_stack_equinox.py
@@ -12,18 +12,6 @@ def test_stack():
     F = 2
     stack_size = 3
 
-    def make_input(x):
-        y = jnp.concatenate([
-            jnp.zeros((stack_size - 1, F)),
-            x[None]
-        ])
-        mask = jnp.concatenate([
-            jnp.zeros((stack_size - 1,)),
-            jnp.array([1.0])
-        ])
-        return y, mask
-
-
     m = Stack(recurrent_size=F, stack_size=stack_size, key=jax.random.key(0))
     x = jnp.arange(T * F, dtype=jnp.float32).reshape((T, F))
     starts = jnp.zeros((T,), dtype=bool)
@@ -51,7 +39,6 @@ def test_stack():
         [x[0], x[1], x[2]],
         [x[1], x[2], x[3]],
     ])
-    breakpoint()
     assert jnp.allclose(
         states,
         tgt

--- a/tests/test_stack_equinox.py
+++ b/tests/test_stack_equinox.py
@@ -1,0 +1,49 @@
+"""Ensure that the reset model is equivalent to a non-reset batched model"""
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+from memorax.equinox.semigroups.stack import Stack
+
+
+def test_stack():
+    T = 4
+    F = 2
+    stack_size = 3
+
+    def make_input(x):
+        y = jnp.concatenate([
+            jnp.zeros((stack_size - 1, F)),
+            x[None]
+        ])
+        mask = jnp.concatenate([
+            jnp.zeros((stack_size - 1,)),
+            jnp.array([1.0])
+        ])
+        return y, mask
+
+
+    m = Stack(recurrent_size=F, stack_size=stack_size, key=jax.random.key(0))
+    inputs = (
+        # x
+        jnp.arange(T * F, dtype=jnp.float32).reshape((T, F)),
+        # starts
+        jnp.zeros((T,), dtype=bool)
+    )
+    h = m.initialize_carry()
+    hs, ys = m(h, inputs)
+    masks = hs[0][1]
+    # mask == [[0,0,1], [0, 1, 1], [1, 1, 1] ... ]
+    assert jnp.allclose(
+        masks,
+        jnp.array([
+            [False, False, True],
+            [False, True, True],
+            [True, True, True],
+            [True, True, True],
+        ])
+    )
+
+if __name__ == "__main__":
+    test_stack()


### PR DESCRIPTION
This PR adds the `Stack` semigroup, which should allow us to implement transformers, fast weight programmers, RWKV, etc that are function of multiple past inputs, rather than just the current input and the recurrent state.