### PR TITLE
Add DeltaProduct model

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ We implement both linear and log-complexity recurrent models.
 | Fast Weight Programmer | $O(\log{n})$ | [[paper]](https://arxiv.org/pdf/2508.08435) | [[code]](memorax/equinox/semigroups/fwp.py) |
 | DeltaNet | $O(\log{n})$ | [[paper]](https://arxiv.org/pdf/2406.06484) | [[code]](memorax/equinox/semigroups/delta.py) |
 | Gated DeltaNet | $O(\log{n})$ | [[paper]](https://arxiv.org/pdf/2412.06464) | [[code]](memorax/equinox/semigroups/gdn.py) |
+| DeltaProduct | $O(\log{n})$ | [[paper]](https://arxiv.org/abs/2502.10297) | [[code]](memorax/equinox/semigroups/deltap.py) |
 | Dot Product Attention | $O(\log{n})$ | [[paper]](https://arxiv.org/abs/1706.03762) | [[code]](memorax/equinox/semigroups/attn.py) |
 | Elman Network | $O(n)$ | [[paper]](https://www.sciencedirect.com/science/article/pii/036402139090002E) | [[code]](memorax/equinox/set_actions/elman.py) |
 | Gated Recurrent Unit | $O(n)$ | [[paper]](https://arxiv.org/abs/1412.3555) | [[code]](memorax/equinox/set_actions/gru.py) |

--- a/memorax/equinox/semigroups/__init__.py
+++ b/memorax/equinox/semigroups/__init__.py
@@ -4,6 +4,7 @@ They are generally much faster than standard RNNs.
 Each RNN type gets its own file.
 + `memorax.equinox.semigroups.attn` provides dot-product attention layer. 
 + `memorax.equinox.semigroups.delta` provides the DeltaNet layer.
++ `memorax.equinox.semigroups.deltap` provides the DeltaProduct layer.
 + `memorax.equinox.semigroups.stack` provides framestacking (sliding-window) as an RNN.
 + `memorax.equinox.semigroups.fart` provides the Fast AutoRegressive Transformer layer.
 + `memorax.equinox.semigroups.ffm` provides the Fast and Forgetful Memory layer.

--- a/memorax/equinox/semigroups/deltap.py
+++ b/memorax/equinox/semigroups/deltap.py
@@ -1,0 +1,142 @@
+from beartype.typing import Callable, List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from beartype import beartype as typechecker
+from equinox import nn
+from jaxtyping import Array, Float, PRNGKeyArray, Shaped, jaxtyped
+
+from memorax.equinox.groups import BinaryAlgebra, Semigroup, Resettable
+from memorax.equinox.gras import GRAS
+from memorax.mtypes import Input, StartFlag
+from memorax.equinox.scans import semigroup_scan
+
+DeltaProductRecurrentState = Tuple[
+    Float[Array, "Key Value"],
+    Float[Array, "Key Value"],
+]
+DeltaProductRecurrentStateWithReset = Tuple[DeltaProductRecurrentState, StartFlag]
+
+
+def phi(x, key=None):
+    # https://arxiv.org/pdf/2102.11174 uses relu
+    # https://arxiv.org/pdf/2406.06484 and 
+    # https://arxiv.org/pdf/2502.10297 use silu
+    return jax.nn.silu(x)
+
+def psi(x, key=None):
+    # https://arxiv.org/pdf/2102.11174 uses sigmoid
+    # https://arxiv.org/pdf/2508.08435 suggests 2 * sigmoid
+    return 2 * jax.nn.sigmoid(x)
+
+
+class DeltaProductSemigroup(Semigroup):
+    """The Fast Weight Programmer w/ Delta update semigroup (recurrent update) 
+    from https://arxiv.org/pdf/2508.08435"""
+
+    recurrent_size: int
+
+    def __init__(self, recurrent_size):
+        self.recurrent_size = recurrent_size
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> DeltaProductRecurrentState:
+        return (
+            jnp.eye(self.recurrent_size),
+            jnp.zeros((self.recurrent_size, self.recurrent_size))
+        )
+
+    @jaxtyped(typechecker=typechecker)
+    def __call__(
+        self,
+        carry: DeltaProductRecurrentState,
+        input: DeltaProductRecurrentState,
+    ) -> DeltaProductRecurrentState:
+        # Amazing resource: https://sustcsonglin.github.io/blog/2024/DeltaProduct-2/
+        # Based on Songlin's factorization
+        M_i, X_i = carry
+        M_j, X_j = input
+        return M_j @ M_i, M_j @ X_i + X_j
+
+
+class DeltaProduct(GRAS):
+    """The Additive Fast Weight Programmer w/ Delta update from https://arxiv.org/pdf/2508.08435
+
+    You might want to use this as a building block for a more complex model.
+    """
+
+    hidden_size: int
+    recurrent_size: int
+    rank: int
+    scan: Callable[
+        [
+            Callable[
+                [DeltaProductRecurrentStateWithReset, DeltaProductRecurrentStateWithReset],
+                DeltaProductRecurrentStateWithReset,
+            ],
+            DeltaProductRecurrentStateWithReset,
+            DeltaProductRecurrentStateWithReset,
+        ],
+        DeltaProductRecurrentStateWithReset,
+    ]
+    algebra: BinaryAlgebra
+
+    K: nn.Linear
+    Q: nn.Linear
+    V: nn.Linear
+    w: nn.Linear
+    output: nn.Linear
+
+    def __init__(self, hidden_size: int, recurrent_size: int, rank: int, key):
+        self.recurrent_size = recurrent_size
+        self.hidden_size = hidden_size
+        self.rank = rank
+        self.algebra = Resettable(DeltaProductSemigroup(recurrent_size))
+        self.scan = semigroup_scan
+
+        keys = jax.random.split(key, 5)
+
+        self.K = nn.Linear(hidden_size, recurrent_size * rank, use_bias=False, key=keys[0])
+        self.Q = nn.Linear(hidden_size, recurrent_size, use_bias=False, key=keys[1])
+        self.V = nn.Linear(hidden_size, recurrent_size * rank, use_bias=False, key=keys[2])
+        self.w = nn.Linear(hidden_size, self.rank, key=keys[3])
+        self.output = nn.Linear(recurrent_size, hidden_size, key=keys[4])
+
+    @jaxtyped(typechecker=typechecker)
+    def forward_map(
+        self, x: Input, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> DeltaProductRecurrentStateWithReset:
+        emb, start = x
+        k = phi(self.K(emb)).reshape(-1, self.rank)
+        k = k / (1e-8 + jnp.linalg.norm(k, axis=0, keepdims=True))
+        v = self.V(emb).reshape(-1, self.rank)
+        beta = psi(self.w(emb)).reshape(-1, self.rank)
+
+        beta_outer = lambda u, v, beta: beta * jnp.outer(u, v)
+
+        # Outer returns tensor of (rank, recurrent, recurrent), sum reduces to (recurrent, recurrent)
+        M = jnp.eye(self.recurrent_size) - jax.vmap(beta_outer, in_axes=-1)(k, k, beta).sum(axis=0)
+        X = jax.vmap(beta_outer, in_axes=-1)(v, k, beta).sum(axis=0)
+        return (M, X), start
+
+    @jaxtyped(typechecker=typechecker)
+    def backward_map(
+        self,
+        h: DeltaProductRecurrentStateWithReset,
+        x: Input,
+        key: Optional[Shaped[PRNGKeyArray, ""]] = None,
+    ) -> Float[Array, "{self.hidden_size}"]:
+        emb, start = x
+        (M, X), reset_flag = h
+        q = phi(self.Q(emb))
+        return self.output(X @ q)
+
+    @jaxtyped(typechecker=typechecker)
+    def initialize_carry(
+        self, key: Optional[Shaped[PRNGKeyArray, ""]] = None
+    ) -> DeltaProductRecurrentStateWithReset:
+        # inputs should be of shape [*batch, time, feature]
+        # recurrent states should be of shape [*batch, 1, feature]
+        return self.algebra.initialize_carry(key)

--- a/memorax/equinox/semigroups/deltap.py
+++ b/memorax/equinox/semigroups/deltap.py
@@ -117,7 +117,7 @@ class DeltaProduct(GRAS):
         beta_outer = lambda u, v, beta: beta * jnp.outer(u, v)
 
         # Outer returns tensor of (rank, recurrent, recurrent), sum reduces to (recurrent, recurrent)
-        M = jnp.eye(self.recurrent_size) - jax.vmap(beta_outer, in_axes=-1)(k, k, beta).sum(axis=0)
+        M = jnp.eye(self.recurrent_size) - jnp.prod(jax.vmap(beta_outer, in_axes=-1)(k, k, beta), axis=0)
         X = jax.vmap(beta_outer, in_axes=-1)(v, k, beta).sum(axis=0)
         return (M, X), start
 

--- a/memorax/equinox/train_utils.py
+++ b/memorax/equinox/train_utils.py
@@ -27,6 +27,7 @@ from memorax.equinox.semigroups.spherical import PSpherical, PSphericalSemigroup
 from memorax.equinox.semigroups.s6 import S6, S6Semigroup
 from memorax.equinox.semigroups.s6d import S6D, S6DSemigroup
 from memorax.equinox.semigroups.delta import DeltaNet, DeltaNetSemigroup
+from memorax.equinox.semigroups.deltap import DeltaProduct, DeltaProductSemigroup
 from memorax.equinox.semigroups.gdn import GDN, GDNSemigroup
 from memorax.equinox.semigroups.mlp import MLP
 from memorax.equinox.semigroups.stack import Stack, StackSemigroup
@@ -229,6 +230,7 @@ def get_semigroups(
         "NMax": NMaxSemigroup(recurrent_size),
         "FWP": FWPSemigroup(recurrent_size),
         "DeltaNet": DeltaNetSemigroup(recurrent_size),
+        "DeltaProduct": DeltaProductSemigroup(recurrent_size),
         "GDN": GDNSemigroup(recurrent_size),
         "Stack": StackSemigroup(recurrent_size, stack_size=4),
         "Attention": AttentionSemigroup(recurrent_size, window_size=4)
@@ -265,6 +267,9 @@ def get_residual_memory_models(
         ),
         "DeltaNet": lambda recurrent_size, key: DeltaNet(
            hidden_size=recurrent_size, recurrent_size=round(recurrent_size ** 0.5), key=key
+        ),
+        "DeltaProduct": lambda recurrent_size, key: DeltaProduct(
+           hidden_size=recurrent_size, recurrent_size=round(recurrent_size ** 0.5), rank=4, key=key
         ),
         "GDN": lambda recurrent_size, key: GDN(
            hidden_size=recurrent_size, recurrent_size=round(recurrent_size ** 0.5), key=key

--- a/tests/test_initial_input_equinox.py
+++ b/tests/test_initial_input_equinox.py
@@ -18,6 +18,7 @@ def get_desired_accuracies():
         "FART": 0.999,
         "FWP": 0.999,
         "DeltaNet": 0.999,
+        "DeltaProduct": 0.999,
         "GDN": 0.999,
         "LRU": 0.999,
         "S6": 0.999,


### PR DESCRIPTION
Adds the DeltaProduct model from https://arxiv.org/abs/2502.10297, which is basically DeltaNet with higher-rank matrices.