### PR TITLE
Improve get_residual_memory_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install "memax[dataset,flax]@git+https://github.com/smorad/memax"
 
 ## Equinox Quickstart
 ```python
-from memax.equinox.train_utils import get_residual_memory_models
+from memax.equinox.train_utils import get_residual_memory_model
 import jax
 import jax.numpy as jnp
 from equinox import filter_jit, filter_vmap
@@ -74,10 +74,10 @@ from memax.equinox.train_utils import add_batch_dim
 
 T, F = 5, 6 # time and feature dim
 
-model = get_residual_memory_models(
-    input=F, hidden=8, output=1, num_layers=2, 
-    models=["LRU"], key=jax.random.key(0)
-)["LRU"]
+model = get_residual_memory_model(
+    model_name="LRU", input=F, hidden=8, output=1, num_layers=2, 
+    key=jax.random.key(0)
+)
 
 starts = jnp.array([True, False, False, True, False])
 xs = jnp.zeros((T, F)) 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Full documentation is available [here](https://smorad.github.io/memax/memax.html
 Please cite the library as
 ```
 @misc{morad_memax_2025,
-	title = {memax},
+	title = {Memax},
 	url = {https://github.com/smorad/memax},
 	author = {Morad, Steven and Toledo, Edan and Kortvelesy, Ryan and He, Zhe},
 	month = jun,

--- a/memax/equinox/semigroups/stack.py
+++ b/memax/equinox/semigroups/stack.py
@@ -90,12 +90,12 @@ class Stack(GRAS):
 
     g: nn.Sequential
 
-    def __init__(self, recurrent_size, stack_size, key):
+    def __init__(self, recurrent_size, window_size, key):
         self.recurrent_size = recurrent_size
-        self.stack_size = stack_size
-        self.algebra = Resettable(StackSemigroup(recurrent_size, stack_size=stack_size))
+        self.stack_size = window_size
+        self.algebra = Resettable(StackSemigroup(recurrent_size, stack_size=window_size))
         self.scan = semigroup_scan
-        self.g = nn.Linear(recurrent_size * stack_size, recurrent_size, key=key)
+        self.g = nn.Linear(recurrent_size * window_size, recurrent_size, key=key)
 
     @jaxtyped(typechecker=typechecker)
     def forward_map(

--- a/memax/linen/train_utils.py
+++ b/memax/linen/train_utils.py
@@ -78,15 +78,17 @@ def loss_classify_terminal_output(
 
 def get_semigroups(
     recurrent_size: int,
+    semigroup_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, FrozenDict]:
     """Returns a dictionary containing all implemented semigroups.
     
     This returns the operator used in the scan, not the full recurrent cell. 
     """
+    semigroup_kwargs = semigroup_kwargs or {}
     return {
-        "FART": FARTSemigroup(recurrent_size),
-        "LRU": LRUSemigroup(recurrent_size),
-        "S6": S6Semigroup(recurrent_size),
+        "FART": FARTSemigroup(recurrent_size, **semigroup_kwargs.get("FART", {})),
+        "LRU": LRUSemigroup(recurrent_size, **semigroup_kwargs.get("LRU", {})),
+        "S6": S6Semigroup(recurrent_size, **semigroup_kwargs.get("S6", {})),
     }
 
 def get_residual_memory_models(

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -73,7 +73,7 @@ def test_readme():
     h, y = eqx.filter_jit(model)(latest_h, inputs)
 
 def test_readme_quickstart():
-    from memax.equinox.train_utils import get_residual_memory_models
+    from memax.equinox.train_utils import get_residual_memory_model
     import jax
     import jax.numpy as jnp
     from equinox import filter_jit, filter_vmap
@@ -81,10 +81,10 @@ def test_readme_quickstart():
 
     T, F = 5, 6 # time and feature dim
 
-    model = get_residual_memory_models(
-        input=F, hidden=8, output=1, num_layers=2, 
-        models=["LRU"], key=jax.random.key(0)
-    )["LRU"]
+    model = get_residual_memory_model(
+        model_name="LRU", input=F, hidden=8, output=1, num_layers=2, 
+        key=jax.random.key(0)
+    )
 
     starts = jnp.array([True, False, False, True, False])
     xs = jnp.zeros((T, F)) 

--- a/tests/test_stack_equinox.py
+++ b/tests/test_stack_equinox.py
@@ -12,7 +12,7 @@ def test_stack():
     F = 2
     stack_size = 3
 
-    m = Stack(recurrent_size=F, stack_size=stack_size, key=jax.random.key(0))
+    m = Stack(recurrent_size=F, window_size=stack_size, key=jax.random.key(0))
     x = jnp.arange(T * F, dtype=jnp.float32).reshape((T, F))
     starts = jnp.zeros((T,), dtype=bool)
     inputs = (x, starts)


### PR DESCRIPTION
This PR improves the usability of the `get_residual_memory_models` and related functions. In particular, it allows propagating keyword arguments to the individual layers.